### PR TITLE
feat: deploy theme thru github action

### DIFF
--- a/.github/workflows/deploy-theme.yml
+++ b/.github/workflows/deploy-theme.yml
@@ -1,0 +1,23 @@
+name: Deploy Theme
+on:
+  push:
+    branches:
+      - master
+      - main
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18.x'
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run build
+      - name: Deploy bellutin theme
+        uses: TryGhost/action-deploy-theme@v1
+        with:
+          api-url: ${{ secrets.GHOST_ADMIN_API_URL }}
+          api-key: ${{ secrets.GHOST_ADMIN_API_KEY }}

--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
-# Bulletin
+# Bellutin
 
-Bulletin is a minimal newsletter theme for [Ghost](https://github.com/TryGhost/Ghost). The theme divides your homepage into two sections. The left-hand section is optimized for capturing new email subscribers with a punchy background color. The right-hand section shows an excerpt from the latest issue you’ve published.
+Bellutin forks from Bulletin, a minimal newsletter theme for [Ghost](https://github.com/TryGhost/Ghost). The theme divides your homepage into two sections. The left-hand section is optimized for capturing new email subscribers. I replaced its background color with the site cover. The right-hand section shows an excerpt from the latest issue you’ve published.
 
-**Demo: https://bulletin.ghost.io**
+**Bulletin demo: https://bulletin.ghost.io**
 
 # Instructions
 
-1. [Download this theme](https://github.com/TryGhost/Bulletin/archive/main.zip)
+1. [Download this theme](https://github.com/BilboTheHobbyist/bellutin/archive/main.zip)
 2. Log into Ghost, and go to the `Design` settings area to upload the zip file
+3. In the `Site wide` tab, set the `Background position` to crop the site cover in post menu.
 
 # Development
 
@@ -28,11 +29,29 @@ The `zip` Gulp task packages the theme files into `dist/bulletin.zip`, which you
 ```bash
 yarn zip
 ```
+# Github actions (WIP)
+
+## Ghost setup
+
+1. In your online site adminsitration, click on `Integrations` menu
+2. Click on the `Add custom integration` link
+3. Give your integration a title such as `Github actions`
+4. Copy the `Admin API key` and `Admin URL` field values 
+
+## Github setup
+
+1. Under your repository name, click on the `Settings` tab
+2. In the left sidebar, click `Secrets`
+3. On the right bar, click on `Add a new secret`
+4. In the `Name` input box, type `GHOST_ADMIN_API_URL`
+5. Type the value for your secret
+6. Click Add secret
+7. Reapeat for `GHOST_ADMIN_API_KEY` secret
 
 # Contribution
 
-This repo is synced automatically with [TryGhost/Themes](https://github.com/TryGhost/Themes) monorepo. If you're looking to contribute or raise an issue, head over to the main repository [TryGhost/Themes](https://github.com/TryGhost/Themes) where our official themes are developed.
+If you're looking to contribute or raise an issue, head over to the main repository [TryGhost/Themes](https://github.com/TryGhost/Themes) where Ghost official themes are developed.
 
 # Copyright & License
 
-Copyright (c) 2013-2023 Ghost Foundation - Released under the [MIT license](LICENSE).
+Copyright (c) bellerad.io - Released under the [MIT license](LICENSE).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-    "name": "bulletin",
-    "description": "A Ghost theme",
+    "name": "bellutin",
+    "description": "A bulletin forked Ghost theme",
     "version": "1.0.0",
     "private": true,
     "engines": {
@@ -8,9 +8,9 @@
     },
     "license": "MIT",
     "author": {
-        "name": "Ghost Foundation",
-        "email": "hello@ghost.org",
-        "url": "https://ghost.org"
+        "name": "Bilbo the Hobbyist",
+        "email": "74491222+BilboTheHobbyist@users.noreply.github.com",
+        "url": "https://www.bellerad.io"
     },
     "keywords": [
         "ghost",


### PR DESCRIPTION
## deploy theme thru github action
### rationale

- in case you can't access your `content/themes/` directory ?
- push into github repo instead of manually zipping / uploading ?
### how-to (not tested)
- cf. [README](https://github.com/BilboTheHobbyist/bellutin/blob/dev/README.md#github-actions-wip)
